### PR TITLE
Add '.stache' file extension support

### DIFF
--- a/grammars/html with mustaches.cson
+++ b/grammars/html with mustaches.cson
@@ -1,7 +1,7 @@
 'fileTypes': [
   'mustache'
   'handlebars'
-  'hbs',
+  'hbs'
   'stache'
 ]
 'name': 'HTML (Mustache)'


### PR DESCRIPTION
CanJS uses .stache for the new engine implementation
