### PR TITLE
Added rac extensions for the ractive.js templates

### DIFF
--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -7,6 +7,7 @@
   'mu'
   'mustache'
   'stache'
+  'rac'
 ]
 'patterns': [
   {


### PR DESCRIPTION
Ractive.js templates use Mustache for it's templating language.
http://docs.ractivejs.org/latest/mustaches

I think we should add language-mustache support for the .rac files too