### PR TITLE
Allow for whitespace in block expressions

### DIFF
--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -35,7 +35,7 @@
     'end': '\\}\\}'
     'name': 'comment.block.mustache'
   'block-expression-start':
-    'begin': '\\{\\{([#^])\\s*([\\w\\.]*)'
+    'begin': '\\{\\{([#^]\\s*)([\\w\\.]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
@@ -49,7 +49,7 @@
         'name': 'entity.name.tag.mustache'
     'name': 'meta.tag.template.mustache'
   'block-expression-end':
-    'begin': '\\{\\{(/)\\s*([\\w\\.]*)'
+    'begin': '\\{\\{([/]\\s*)([\\w\\.]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'

--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -35,7 +35,7 @@
     'end': '\\}\\}'
     'name': 'comment.block.mustache'
   'block-expression-start':
-    'begin': '\\{\\{([#^])\\s*(\\w*)'
+    'begin': '\\{\\{([#^])\\s*([\\w\\.]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
@@ -49,7 +49,7 @@
         'name': 'entity.name.tag.mustache'
     'name': 'meta.tag.template.mustache'
   'block-expression-end':
-    'begin': '\\{\\{(/)\\s*(\\w*)'
+    'begin': '\\{\\{(/)\\s*([\\w\\.]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'

--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -35,7 +35,7 @@
     'end': '\\}\\}'
     'name': 'comment.block.mustache'
   'block-expression-start':
-    'begin': '\\{\\{([#^])(\\w*)'
+    'begin': '\\{\\{([#^])\\s*(\\w*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
@@ -43,13 +43,13 @@
         'name': 'punctuation.definition.block.begin.mustache'
       '2':
         'name': 'entity.name.function.mustache'
-    'end': '\\}\\}'
+    'end': '\\s*\\}\\}'
     'endCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
     'name': 'meta.tag.template.mustache'
   'block-expression-end':
-    'begin': '\\{\\{(/)(\\w*)'
+    'begin': '\\{\\{(/)\\s*(\\w*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
@@ -57,7 +57,7 @@
         'name': 'punctuation.definition.block.end.mustache'
       '2':
         'name': 'entity.name.function.mustache'
-    'end': '\\}\\}'
+    'end': '\\s*\\}\\}'
     'endCaptures':
       '0':
         'name': 'entity.name.tag.mustache'

--- a/spec/mustache-spec.coffee
+++ b/spec/mustache-spec.coffee
@@ -35,6 +35,13 @@ describe 'Mustache grammar', ->
     expect(tokens[3]).toEqual value: ' people', scopes: ['text.html.mustache', 'meta.tag.template.mustache']
     expect(tokens[4]).toEqual value: '}}', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
 
+    {tokens} = grammar.tokenizeLine("{{# nested.block }}")
+
+    expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+    expect(tokens[1]).toEqual value: '# ', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache', 'punctuation.definition.block.begin.mustache']
+    expect(tokens[2]).toEqual value: 'nested.block', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache', 'entity.name.function.mustache']
+    expect(tokens[3]).toEqual value: ' }}', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+
     {tokens} = grammar.tokenizeLine("{{^repo}}")
 
     expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']


### PR DESCRIPTION
This fixes an issue where block expressions would only be identified if there are no whitespace wrapping the expression name. I.e. `{{#foo}}` would be identified as a block expression while as `{{# foo }}` would not.

## Before
![screen shot 2015-08-19 at 12 43 07](https://cloud.githubusercontent.com/assets/985518/9354393/543af29a-4670-11e5-9a88-5f97562a4cbf.png)

## After
![screen shot 2015-08-19 at 12 42 39](https://cloud.githubusercontent.com/assets/985518/9354404/5bc7e950-4670-11e5-8a76-02954cbdc3c4.png)
