### PR TITLE
Use injections

### DIFF
--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -11,7 +11,7 @@
   'stache'
 ]
 'injections':
-  'L:text.html.mustache':
+  'L:text.html.mustache - (meta.tag.template.mustache | comment.block.mustache)':
     'patterns': [
       {
         'include': '#comment'

--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -10,22 +10,26 @@
   'ractive'
   'stache'
 ]
+'injections':
+  'L:text.html.mustache':
+    'patterns': [
+      {
+        'include': '#comment'
+      }
+      {
+        'include': '#block-expression-start'
+      }
+      {
+        'include': '#block-expression-end'
+      }
+      {
+        'include': '#escape'
+      }
+      {
+        'include': '#template'
+      }
+    ]
 'patterns': [
-  {
-    'include': '#comment'
-  }
-  {
-    'include': '#block-expression-start'
-  }
-  {
-    'include': '#block-expression-end'
-  }
-  {
-    'include': '#escape'
-  }
-  {
-    'include': '#template'
-  }
   {
     'include': 'text.html.basic'
   }

--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -36,11 +36,11 @@
 ]
 'repository':
   'comment':
-    'begin': '\\{\\{!'
-    'end': '\\}\\}'
+    'begin': '{{!'
+    'end': '}}'
     'name': 'comment.block.mustache'
   'block-expression-start':
-    'begin': '\\{\\{([#^]\\s*)([\\w\\.]*)'
+    'begin': '{{([#^]\\s*)([\\w\\.]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
@@ -48,13 +48,13 @@
         'name': 'punctuation.definition.block.begin.mustache'
       '2':
         'name': 'entity.name.function.mustache'
-    'end': '\\s*\\}\\}'
+    'end': '\\s*}}'
     'endCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
     'name': 'meta.tag.template.mustache'
   'block-expression-end':
-    'begin': '\\{\\{([/]\\s*)([\\w\\.]*)'
+    'begin': '{{([/]\\s*)([\\w\\.]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
@@ -62,21 +62,21 @@
         'name': 'punctuation.definition.block.end.mustache'
       '2':
         'name': 'entity.name.function.mustache'
-    'end': '\\s*\\}\\}'
+    'end': '\\s*}}'
     'endCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
     'name': 'meta.tag.template.mustache'
   'escape':
-    'begin': '\\{\\{\\{'
-    'end': '\\}\\}\\}'
+    'begin': '{{{'
+    'end': '}}}'
     'captures':
       '0':
         'name': 'entity.name.tag.mustache'
     'name': 'meta.tag.template.raw.mustache'
   'template':
-    'begin': '\\{\\{[<>]?'
-    'end': '\\}\\}'
+    'begin': '{{[<>]?'
+    'end': '}}'
     'captures':
       '0':
         'name': 'entity.name.tag.mustache'

--- a/spec/mustache-spec.coffee
+++ b/spec/mustache-spec.coffee
@@ -3,6 +3,9 @@ describe 'Mustache grammar', ->
 
   beforeEach ->
     waitsForPromise ->
+      atom.packages.activatePackage('language-html')
+
+    waitsForPromise ->
       atom.packages.activatePackage('language-mustache')
 
     runs ->
@@ -18,6 +21,13 @@ describe 'Mustache grammar', ->
     expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
     expect(tokens[1]).toEqual value: 'name', scopes: ['text.html.mustache', 'meta.tag.template.mustache']
     expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+
+  it 'parses expressions in HTML attributes', ->
+    {tokens} = grammar.tokenizeLine("<a href='{{test}}'></a>")
+
+    expect(tokens[6]).toEqual value: '{{', scopes: ['text.html.mustache', 'meta.tag.any.html', 'string.quoted.single.html', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+    expect(tokens[8]).toEqual value: '}}', scopes: ['text.html.mustache', 'meta.tag.any.html', 'string.quoted.single.html', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+    expect(tokens[9]).toEqual value: "'", scopes: ['text.html.mustache', 'meta.tag.any.html', 'string.quoted.single.html', 'punctuation.definition.string.end.html']
 
   it 'parses comments', ->
     {tokens} = grammar.tokenizeLine("{{!comment}}")

--- a/spec/mustache-spec.coffee
+++ b/spec/mustache-spec.coffee
@@ -72,3 +72,19 @@ describe 'Mustache grammar', ->
     expect(tokens[0]).toEqual value: '{{{', scopes: ['text.html.mustache', 'meta.tag.template.raw.mustache', 'entity.name.tag.mustache']
     expect(tokens[1]).toEqual value: 'do not escape me', scopes: ['text.html.mustache', 'meta.tag.template.raw.mustache']
     expect(tokens[2]).toEqual value: '}}}', scopes: ['text.html.mustache', 'meta.tag.template.raw.mustache', 'entity.name.tag.mustache']
+
+  it 'does not tokenize tags within tags', ->
+    {tokens} = grammar.tokenizeLine("{{test{{test}}}}")
+
+    expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+    expect(tokens[1]).toEqual value: 'test{{test', scopes: ['text.html.mustache', 'meta.tag.template.mustache']
+    expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+    expect(tokens[3]).toEqual value: '}}', scopes: ['text.html.mustache']
+
+  it 'does not tokenize comments within comments', ->
+    {tokens} = grammar.tokenizeLine("{{!test{{!test}}}}")
+
+    expect(tokens[0]).toEqual value: '{{!', scopes: ['text.html.mustache', 'comment.block.mustache']
+    expect(tokens[1]).toEqual value: 'test{{!test', scopes: ['text.html.mustache', 'comment.block.mustache']
+    expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'comment.block.mustache']
+    expect(tokens[3]).toEqual value: '}}', scopes: ['text.html.mustache']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Injections allow Mustache tags to be tokenized everywhere inside HTML, including in HTML attributes and CSS styles.  The second commit just cleans up the grammar by removing unneeded escapes sequences.

### Alternate Designs

None

### Benefits

Mustache gets tokenized everywhere.

### Possible Drawbacks

I don't foresee any.

### Applicable Issues

Fixes #10
Fixes #11
Fixes #19