### PR TITLE
Adjust captures

### DIFF
--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -37,10 +37,16 @@
 'repository':
   'comment':
     'begin': '{{!'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.mustache'
     'end': '}}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.mustache'
     'name': 'comment.block.mustache'
   'block-expression-start':
-    'begin': '{{([#^]\\s*)([\\w\\.]*)'
+    'begin': '{{([#^])\\s*([\\w\\.]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
@@ -48,13 +54,13 @@
         'name': 'punctuation.definition.block.begin.mustache'
       '2':
         'name': 'entity.name.function.mustache'
-    'end': '\\s*}}'
+    'end': '\\s*(}})'
     'endCaptures':
-      '0':
+      '1':
         'name': 'entity.name.tag.mustache'
     'name': 'meta.tag.template.mustache'
   'block-expression-end':
-    'begin': '{{([/]\\s*)([\\w\\.]*)'
+    'begin': '{{(/)\\s*([\\w\\.]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.mustache'
@@ -62,9 +68,9 @@
         'name': 'punctuation.definition.block.end.mustache'
       '2':
         'name': 'entity.name.function.mustache'
-    'end': '\\s*}}'
+    'end': '\\s*(}})'
     'endCaptures':
-      '0':
+      '1':
         'name': 'entity.name.tag.mustache'
     'name': 'meta.tag.template.mustache'
   'escape':

--- a/spec/mustache-spec.coffee
+++ b/spec/mustache-spec.coffee
@@ -32,9 +32,9 @@ describe 'Mustache grammar', ->
   it 'parses comments', ->
     {tokens} = grammar.tokenizeLine("{{!comment}}")
 
-    expect(tokens[0]).toEqual value: '{{!', scopes: ['text.html.mustache', 'comment.block.mustache']
+    expect(tokens[0]).toEqual value: '{{!', scopes: ['text.html.mustache', 'comment.block.mustache', 'punctuation.definition.comment.mustache']
     expect(tokens[1]).toEqual value: 'comment', scopes: ['text.html.mustache', 'comment.block.mustache']
-    expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'comment.block.mustache']
+    expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'comment.block.mustache', 'punctuation.definition.comment.mustache']
 
   it 'parses block expression', ->
     {tokens} = grammar.tokenizeLine("{{#each people}}")
@@ -48,9 +48,9 @@ describe 'Mustache grammar', ->
     {tokens} = grammar.tokenizeLine("{{# nested.block }}")
 
     expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
-    expect(tokens[1]).toEqual value: '# ', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache', 'punctuation.definition.block.begin.mustache']
-    expect(tokens[2]).toEqual value: 'nested.block', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache', 'entity.name.function.mustache']
-    expect(tokens[3]).toEqual value: ' }}', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+    expect(tokens[1]).toEqual value: '#', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache', 'punctuation.definition.block.begin.mustache']
+    expect(tokens[3]).toEqual value: 'nested.block', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache', 'entity.name.function.mustache']
+    expect(tokens[5]).toEqual value: '}}', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
 
     {tokens} = grammar.tokenizeLine("{{^repo}}")
 
@@ -84,7 +84,7 @@ describe 'Mustache grammar', ->
   it 'does not tokenize comments within comments', ->
     {tokens} = grammar.tokenizeLine("{{!test{{!test}}}}")
 
-    expect(tokens[0]).toEqual value: '{{!', scopes: ['text.html.mustache', 'comment.block.mustache']
+    expect(tokens[0]).toEqual value: '{{!', scopes: ['text.html.mustache', 'comment.block.mustache', 'punctuation.definition.comment.mustache']
     expect(tokens[1]).toEqual value: 'test{{!test', scopes: ['text.html.mustache', 'comment.block.mustache']
-    expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'comment.block.mustache']
+    expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'comment.block.mustache', 'punctuation.definition.comment.mustache']
     expect(tokens[3]).toEqual value: '}}', scopes: ['text.html.mustache']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Add `punctuation.definition.comment.mustache` for comments
* Adjust matches so that they don't capture whitespace

### Alternate Designs

None

### Benefits

More accurate scopes

### Possible Drawbacks

None

### Applicable Issues

None
