### PR TITLE
Add master pattern

### DIFF
--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -15,6 +15,23 @@
   'L:text.html.mustache - (meta.tag.template.mustache | comment.block.mustache)':
     'patterns': [
       {
+        # This should be the only pattern here!
+        # Add everything else into #mustache below
+        'include': '#mustache'
+      }
+    ]
+'patterns': [
+  {
+    'include': 'text.html.basic'
+  }
+]
+'repository':
+  # The master pattern. All new patterns should be added here instead of in
+  # 'injections' to make including this language easier.
+  # See https://github.com/atom/language-mustache/issues/26
+  'mustache':
+    'patterns': [
+      {
         'include': '#comment'
       }
       {
@@ -30,12 +47,6 @@
         'include': '#template'
       }
     ]
-'patterns': [
-  {
-    'include': 'text.html.basic'
-  }
-]
-'repository':
   'comment':
     'begin': '{{!'
     'beginCaptures':

--- a/grammars/sql with mustaches.cson
+++ b/grammars/sql with mustaches.cson
@@ -4,7 +4,7 @@
 ]
 'patterns': [
   {
-    'include': 'text.html.mustache'
+    'include': 'text.html.mustache#mustache'
   }
   {
     'include': 'source.sql'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This adds a master pattern, `#mustache`, that includes all other patterns that should be injected into HTML.  This is to make it easier for other grammars to include language-mustache, as injections are not included.

Also, I fixed the SQL Mustache grammar.

### Alternate Designs

Splitting up the grammar files, but I can't think of a good scope name for standalone Mustache.

### Benefits

Including language-mustache can now be done through `'include': 'text.html.mustache#mustache'`.

### Possible Drawbacks

None.

### Applicable Issues

Closes #26

/cc @caleb531