### PR TITLE
Adds support for handlebars `{{!--` style comments

### DIFF
--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -32,7 +32,10 @@
   'mustache':
     'patterns': [
       {
-        'include': '#comment'
+        'include': '#block-comment'
+      }
+      {
+        'include': '#inline-comment'
       }
       {
         'include': '#block-expression-start'
@@ -47,7 +50,17 @@
         'include': '#template'
       }
     ]
-  'comment':
+  'block-comment':
+    'begin': '{{!--'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.mustache'
+    'end': '--}}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.mustache'
+    'name': 'comment.block.mustache'
+  'inline-comment':
     'begin': '{{!'
     'beginCaptures':
       '0':

--- a/spec/mustache-spec.coffee
+++ b/spec/mustache-spec.coffee
@@ -36,6 +36,13 @@ describe 'Mustache grammar', ->
     expect(tokens[8]).toEqual value: '}}', scopes: ['text.html.mustache', scopes..., 'string.quoted.single.html', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
     expect(tokens[9]).toEqual value: "'", scopes: ['text.html.mustache', scopes..., 'string.quoted.single.html', 'punctuation.definition.string.end.html']
 
+  it 'parses block comments', ->
+    {tokens} = grammar.tokenizeLine("{{!--{{comment}}--}}")
+
+    expect(tokens[0]).toEqual value: '{{!--', scopes: ['text.html.mustache', 'comment.block.mustache', 'punctuation.definition.comment.mustache']
+    expect(tokens[1]).toEqual value: '{{comment}}', scopes: ['text.html.mustache', 'comment.block.mustache']
+    expect(tokens[2]).toEqual value: '--}}', scopes: ['text.html.mustache', 'comment.block.mustache', 'punctuation.definition.comment.mustache']
+
   it 'parses comments', ->
     {tokens} = grammar.tokenizeLine("{{!comment}}")
 


### PR DESCRIPTION
### Description of the Change

This adds support for [handlebars style block comments](http://handlebarsjs.com/#comments)

```handlebars
{{!-- this is a comment that {{contains}} some handlebars
  and is terminated with double dash + double braces: --}}
```

### Benefits

Previously a handlebars style bock comment that contained a handlebars expression was not properly highlighted.

### Applicable Issues

This PR resolves #30.
