### PR TITLE
Do not tokenize Mustache expressions inside HTML comments

### DIFF
--- a/grammars/mustache.cson
+++ b/grammars/mustache.cson
@@ -12,7 +12,7 @@
   'stache'
 ]
 'injections':
-  'L:text.html.mustache - (meta.tag.template.mustache | comment.block.mustache)':
+  'L:text.html.mustache - (meta.tag.template.mustache | comment.block)':
     'patterns': [
       {
         # This should be the only pattern here!

--- a/spec/mustache-spec.coffee
+++ b/spec/mustache-spec.coffee
@@ -23,18 +23,11 @@ describe 'Mustache grammar', ->
     expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
 
   it 'parses expressions in HTML attributes', ->
-    # TODO: Remove after Atom 1.21 is released
-    scopes = null
-    if parseFloat(atom.getVersion()) <= 1.21
-      scopes = ['meta.tag.any.html']
-    else
-      scopes = ['meta.tag.inline.a.html', 'meta.attribute-with-value.html']
-
     {tokens} = grammar.tokenizeLine("<a href='{{test}}'></a>")
 
-    expect(tokens[6]).toEqual value: '{{', scopes: ['text.html.mustache', scopes..., 'string.quoted.single.html', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
-    expect(tokens[8]).toEqual value: '}}', scopes: ['text.html.mustache', scopes..., 'string.quoted.single.html', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
-    expect(tokens[9]).toEqual value: "'", scopes: ['text.html.mustache', scopes..., 'string.quoted.single.html', 'punctuation.definition.string.end.html']
+    expect(tokens[6]).toEqual value: '{{', scopes: ['text.html.mustache', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.single.html', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+    expect(tokens[8]).toEqual value: '}}', scopes: ['text.html.mustache', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.single.html', 'meta.tag.template.mustache', 'entity.name.tag.mustache']
+    expect(tokens[9]).toEqual value: "'", scopes: ['text.html.mustache', 'meta.tag.inline.a.html', 'meta.attribute-with-value.html', 'string.quoted.single.html', 'punctuation.definition.string.end.html']
 
   it 'parses block comments', ->
     {tokens} = grammar.tokenizeLine("{{!--{{comment}}--}}")

--- a/spec/mustache-spec.coffee
+++ b/spec/mustache-spec.coffee
@@ -95,3 +95,10 @@ describe 'Mustache grammar', ->
     expect(tokens[1]).toEqual value: 'test{{!test', scopes: ['text.html.mustache', 'comment.block.mustache']
     expect(tokens[2]).toEqual value: '}}', scopes: ['text.html.mustache', 'comment.block.mustache', 'punctuation.definition.comment.mustache']
     expect(tokens[3]).toEqual value: '}}', scopes: ['text.html.mustache']
+
+  it 'does not tokenize Mustache expressions inside HTML comments', ->
+    {tokens} = grammar.tokenizeLine("<!--{{test}}-->")
+
+    expect(tokens[0]).toEqual value: '<!--', scopes: ['text.html.mustache', 'comment.block.html', 'punctuation.definition.comment.html']
+    expect(tokens[1]).toEqual value: '{{test}}', scopes: ['text.html.mustache', 'comment.block.html']
+    expect(tokens[2]).toEqual value: '-->', scopes: ['text.html.mustache', 'comment.block.html', 'punctuation.definition.comment.html']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Relax the injection selector preventing comments from being included to match all comments, not just Mustache comments.

### Alternate Designs

None.

### Benefits

Mustache expressions will not be tokenized in HTML comments.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #32